### PR TITLE
test: refactor tests for ease of use

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,9 @@
   "extends": "airbnb-base",
   "rules": {
     "no-underscore-dangle": 0
+  },
+  "env": {
+    "mocha": true,
+    "node": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -493,6 +493,15 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.14.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -555,6 +564,22 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -571,6 +596,12 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "bson": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg==",
+      "dev": true
+    },
     "bson-objectid": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/bson-objectid/-/bson-objectid-1.3.1.tgz",
@@ -580,6 +611,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "caller-callsite": {
@@ -2944,6 +2981,12 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
+      "dev": true
+    },
     "detect-indent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
@@ -3097,6 +3140,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -4496,6 +4545,18 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hooks": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.3.2.tgz",
+      "integrity": "sha1-ox8GDCAmzqbPHKPrF4Qw5xjhxKM=",
+      "dev": true
+    },
+    "hooks-fixed": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz",
+      "integrity": "sha512-YurCM4gQSetcrhwEtpQHhQ4M7Zo7poNGqY4kQGeBS6eZtOcT3tnNs01ThFa0jYBByAiYt1MjMjP/YApG0EnAvQ==",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -5043,6 +5104,19 @@
         "verror": "1.10.0"
       }
     },
+    "kareem": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz",
+      "integrity": "sha1-4+QQHZ3P3imXadr0tNtk2JXRdEg=",
+      "dev": true
+    },
+    "kerberos": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.4.tgz",
+      "integrity": "sha1-EYNmOPcpovbFuuBWp9ehWJjJunw=",
+      "dev": true,
+      "optional": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -5189,6 +5263,13 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "optional": true
     },
     "meow": {
       "version": "5.0.0",
@@ -5413,16 +5494,493 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "mongodb": {
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
+      "integrity": "sha1-o09Zu+thdUrsQy3nLD/iFSakTBo=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.18",
+        "readable-stream": "2.2.7"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+          "dev": true,
+          "requires": {
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "mongodb-core": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
+      "integrity": "sha1-TEYTm986HwMt7ZHbSfOO7AFlkFA=",
+      "dev": true,
+      "requires": {
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
+      "dev": true
+    },
+    "mongoose3": {
+      "version": "npm:mongoose@3.9.7",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-3.9.7.tgz",
+      "integrity": "sha1-sxXm6+XO/M44Q1BLeR8DiCgEjaY=",
+      "dev": true,
+      "requires": {
+        "async": "0.9.0",
+        "hooks": "0.3.2",
+        "kareem": "0.0.4",
+        "mongodb": "1.4.12",
+        "mpath": "0.1.1",
+        "mpromise": "0.5.4",
+        "mquery": "1.0.0",
+        "ms": "0.1.0",
+        "muri": "0.3.1",
+        "regexp-clone": "0.0.1",
+        "sliced": "0.0.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+          "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc=",
+          "dev": true
+        },
+        "bson": {
+          "version": "0.2.22",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz",
+          "integrity": "sha1-/NoQPybQwHTVpS1Qkn24D9ArSzk=",
+          "dev": true,
+          "requires": {
+            "nan": "~1.8"
+          }
+        },
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+          "dev": true
+        },
+        "kareem": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/kareem/-/kareem-0.0.4.tgz",
+          "integrity": "sha1-qEdd79dM+CmwBx0g5pcb8V2RHSs=",
+          "dev": true
+        },
+        "mongodb": {
+          "version": "1.4.12",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.12.tgz",
+          "integrity": "sha1-Zc3UbsEnhh6UEWj9zPgr8XrXHE0=",
+          "dev": true,
+          "requires": {
+            "bson": "~0.2",
+            "kerberos": "0.0.4",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "mpath": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz",
+          "integrity": "sha1-I9qFK3wjLuCX9HWdKcDunNItXkY=",
+          "dev": true
+        },
+        "mpromise": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz",
+          "integrity": "sha1-thBhPsbeN0GflEs18Hg7Ten13HU=",
+          "dev": true
+        },
+        "mquery": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.0.0.tgz",
+          "integrity": "sha1-aUCkbWQzaP6OWr3euUvY3TIBP1s=",
+          "dev": true,
+          "requires": {
+            "debug": "0.7.4",
+            "regexp-clone": "0.0.1",
+            "sliced": "0.0.5"
+          }
+        },
+        "ms": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.1.0.tgz",
+          "integrity": "sha1-8h+sSQ2vHXZn/RgP6QdzicyUQrI=",
+          "dev": true
+        },
+        "muri": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/muri/-/muri-0.3.1.tgz",
+          "integrity": "sha1-hhiJxchX8aQ3AL7oXVBzH2FyfJo=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8=",
+          "dev": true
+        }
+      }
+    },
+    "mongoose4": {
+      "version": "npm:mongoose@4.13.21",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.21.tgz",
+      "integrity": "sha512-0VZtQu1rSUPwUtbb7zh6CymI0nNkVInOIDbtWNlna070qnUO14On8PpSVSwlx3gwmkKL2OkP4ioCj5YHC6trMg==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "bson": "~1.0.4",
+        "hooks-fixed": "2.0.2",
+        "kareem": "1.5.0",
+        "lodash.get": "4.4.2",
+        "mongodb": "2.2.34",
+        "mpath": "0.5.1",
+        "mpromise": "0.5.5",
+        "mquery": "2.3.3",
+        "ms": "2.0.0",
+        "muri": "1.3.0",
+        "regexp-clone": "0.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "mongoose5": {
+      "version": "npm:mongoose@5.10.15",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.15.tgz",
+      "integrity": "sha512-3QUWCpMRdFCPIBZkjG/B2OkfMY2WLkR+hv335o4T2mn3ta9kx8qVvXeUDojp3OHMxBZVUyCA+hDyyP4/aKmHuA==",
+      "dev": true,
+      "requires": {
+        "bson": "^1.1.4",
+        "kareem": "2.3.1",
+        "mongodb": "3.6.3",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.7.0",
+        "mquery": "3.2.2",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "safe-buffer": "5.2.1",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "bson": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "kareem": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
+          "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==",
+          "dev": true
+        },
+        "mongodb": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+          "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+          "dev": true,
+          "requires": {
+            "bl": "^2.2.1",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
+        "mpath": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
+          "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg==",
+          "dev": true
+        },
+        "mquery": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
+          "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
+          "dev": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "debug": "3.1.0",
+            "regexp-clone": "^1.0.0",
+            "safe-buffer": "5.1.2",
+            "sliced": "1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "regexp-clone": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+          "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
+    "mongooseLatest": {
+      "version": "npm:mongoose@5.10.15",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.15.tgz",
+      "integrity": "sha512-3QUWCpMRdFCPIBZkjG/B2OkfMY2WLkR+hv335o4T2mn3ta9kx8qVvXeUDojp3OHMxBZVUyCA+hDyyP4/aKmHuA==",
+      "dev": true,
+      "requires": {
+        "bson": "^1.1.4",
+        "kareem": "2.3.1",
+        "mongodb": "3.6.3",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.7.0",
+        "mquery": "3.2.2",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "safe-buffer": "5.2.1",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "bson": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "kareem": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
+          "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==",
+          "dev": true
+        },
+        "mongodb": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+          "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+          "dev": true,
+          "requires": {
+            "bl": "^2.2.1",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
+        "mpath": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
+          "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg==",
+          "dev": true
+        },
+        "mquery": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
+          "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
+          "dev": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "debug": "3.1.0",
+            "regexp-clone": "^1.0.0",
+            "safe-buffer": "5.1.2",
+            "sliced": "1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "regexp-clone": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+          "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
+    "mpath": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+      "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg==",
+      "dev": true
+    },
+    "mpromise": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
+      "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY=",
+      "dev": true
+    },
+    "mquery": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.3.tgz",
+      "integrity": "sha512-NC8L14kn+qxJbbJ1gbcEMDxF0sC3sv+1cbRReXXwVvowcwY1y9KoVZFq0ebwARibsadu8lx8nWGvm3V0Pf0ZWQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "debug": "2.6.9",
+        "regexp-clone": "0.0.1",
+        "sliced": "0.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8=",
+          "dev": true
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "muri": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/muri/-/muri-1.3.0.tgz",
+      "integrity": "sha512-FiaFwKl864onHFFUV/a2szAl7X0fxVlSKNdhTf+BM8i8goEgYut8u5P9MqQqIYwvaMxjzVESsoEm/2kfkFH1rg==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nan": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+      "integrity": "sha1-PHa1OC6rM+RLdY0oE8qdkuk0LzQ=",
       "dev": true
     },
     "natural-compare": {
@@ -8437,6 +8995,12 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regexp-clone": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+      "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk=",
+      "dev": true
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -8491,6 +9055,24 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        }
+      }
     },
     "resolve": {
       "version": "1.15.1",
@@ -8565,6 +9147,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -8615,6 +9207,12 @@
         "rechoir": "^0.6.2"
       }
     },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -8638,11 +9236,27 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
+      "dev": true
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,6 @@
   },
   "scripts": {
     "test": "npx mocha test/*",
-    "test:any": "npm t && npm r mongoose",
-    "test:all": "npm run lint:fix && npm run test:latest && npm run test:v5 && npm run test:v4",
-    "test:v3": "npm r mongoose && npm i mongoose@3.x && npm run test:any",
-    "test:v4": "npm r mongoose && npm i mongoose@4.x && npm run test:any",
-    "test:v5": "npm r mongoose && npm i mongoose@5.x && npm run test:any",
-    "test:latest": "npm r mongoose && npm i mongoose && npm run test:any",
     "lint": "npx eslint lib/*.js",
     "lint:fix": "npm run lint -- --fix",
     "version:inc": "npm version patch && git push && git push --tags",
@@ -63,6 +57,10 @@
     "husky": "^4.2.3",
     "mocha": "^6.2.2",
     "mocha-lcov-reporter": "^1.3.0",
+    "mongoose3": "npm:mongoose@^3.9.7",
+    "mongoose4": "npm:mongoose@^4.13.21",
+    "mongoose5": "npm:mongoose@^5.10.14",
+    "mongooseLatest": "npm:mongoose@^5.10.14",
     "nyc": "^11.6.0",
     "standard-version": "^8.0.2"
   },
@@ -83,7 +81,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-push": "npm run test:all"
+      "pre-push": "npm run test"
     }
   }
 }

--- a/test/mocker.test.js
+++ b/test/mocker.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const get = require('lodash.get');
 const { unflatten } = require('flat');
 
-const mongoose3 = require('mongoose3');
+// const mongoose3 = require('mongoose3');
 const mongoose4 = require('mongoose4');
 const mongoose5 = require('mongoose5');
 const mongooseLatest = require('mongooseLatest');


### PR DESCRIPTION
Refactor test suite to loop over different versions of dependency 'mongoose' for quicker and simpler test runs
 - Add aliased versions of `mongoose` to devDependencies
 - Loop over test config array per `mocha` docs
 - Update `eslintrc` to remove errors for `describe` and `it`
 - Leave TODO for commented out `mongoose3` tests as this is a known issue